### PR TITLE
Fix self-echo causing random DMs

### DIFF
--- a/signal_interface/signal_consumer.py
+++ b/signal_interface/signal_consumer.py
@@ -265,6 +265,14 @@ class SignalConsumer:
 
         self.update_contact_info(msg)
 
+        # Ignore messages sent by the bot itself. Sometimes Signal will echo
+        # back messages that we've just sent (sync messages), which can cause
+        # the Razzler to respond to its own messages. This manifests as the bot
+        # sending apparently unprompted direct messages.
+        if msg.envelope.sourceNumber == self.signal_info.phone_number:
+            logger.debug("Ignoring message sent by ourselves")
+            return
+
         # Dont publish message reciepts to the queue
         if msg.envelope.receiptMessage:
             logger.debug("Receipt message received")


### PR DESCRIPTION
## Summary
- ignore messages that originate from the bot's own phone number

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6853f8cc3e3083209452f39bb6c65f44