### PR TITLE
Fix DM bug by correctly storing groups in phonebook

### DIFF
--- a/utils/phonebook.py
+++ b/utils/phonebook.py
@@ -155,7 +155,11 @@ class PhoneBook(BaseModel):
 
         parsed_group = Group(**group)
 
-        self.groups[parsed_group.internal_id] = parsed_group
+        # Store groups keyed by the public group ID. This lets us
+        # look up the corresponding internal_id when we need to send a
+        # message back to the group.
+        self.groups[parsed_group.id] = parsed_group
 
     def get_group_internal_id(self, group_id: str) -> str:
-        return self.groups[group_id].id
+        """Return the internal_id for a given group id."""
+        return self.groups[group_id].internal_id


### PR DESCRIPTION
## Summary
- fix lookup of groups in the phonebook to avoid accidental direct messages

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853f8cc3e3083209452f39bb6c65f44